### PR TITLE
Requests completion handlers are executed from the main thread

### DIFF
--- a/Pod/Classes/Aerodramus.m
+++ b/Pod/Classes/Aerodramus.m
@@ -188,7 +188,13 @@
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     configuration.requestCachePolicy = NSURLRequestReloadIgnoringCacheData;
     NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
-    NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:completionHandler];
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        if (completionHandler) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionHandler(data, response, error);
+            });
+        }
+    }];
     [task resume];
 }
 


### PR DESCRIPTION
`NSURLSession` invokes its completion handler on some random background thread, which can lead to the following race condition:

- Eigen starts updating Echo.
- User taps a button, which gets routed through the switchboard.
- While the routing is happening, Echo comes back with new config and the switchboard tries to modify its routes, leading to [this crash](https://sentry.io/organizations/artsynet/issues/942429014/?project=166784&referrer=slack&statsPeriod=14d), I suspect.

This PR moves all completion handler calls to the main thread (the same thread that routing happens on, which should fix the crash).

Now, there's a _separate_ issue related to Echo that I need to follow-up about: I suspect that we're constantly fetching new config and replacing our routes, based on some logs I saw on @l2succes's machine earlier today. I'm still confirming that and haven't been able to reproduce the behaviour locally yet. 